### PR TITLE
Add demo link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-gestures"
-description = "Drag, Pinch, and Hover gestures for dioxus components"
+description = "Drag, Pinch, and Hover gestures for dioxus components."
 version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/wakefullynx/dioxus-gestures"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [`Drag`][], [`Pinch`][], and [`Hover`][] gestures for dioxus components.
 
-Please note: This crate is in early development and may contain bugs and missing implementations.
+Demo: https://wakefullynx.dev/dioxus-gestures-demo/
+
+Please note: This crate is in early development and may contain bugs and missing implementations. Currently only tested in `web`.
 
 [`Drag`]: https://docs.rs/dioxus_gestures/latest/state/gestures/drag/struct.Drag
 [`Pinch`]: https://docs.rs/dioxus_gestures/latest/state/gestures/pinch/struct.Pinch


### PR DESCRIPTION
Add a link to a mini demo showcasing the functionality.

Closes #11.