### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,4 @@ license = "MIT"
 
 [dependencies]
 dioxus = "0.7.1"
-dioxus-core = "0.7.1"
-generational-box = "0.7.1"
 paste = "1.0.15"

--- a/src/state/external_handlers.rs
+++ b/src/state/external_handlers.rs
@@ -1,5 +1,4 @@
-use dioxus::{html::PointerData, prelude::EventHandler};
-use dioxus_core::Event;
+use dioxus::{core::Event, html::PointerData, prelude::EventHandler};
 
 use crate::state::events::PointerEventReceiver;
 

--- a/src/state/gestures/down_pointer.rs
+++ b/src/state/gestures/down_pointer.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
+use dioxus::core::Event;
 use dioxus::html::PointerData;
-use dioxus_core::Event;
 
 use crate::state::{
     events::PointerEventReceiver,

--- a/src/use_gestures.rs
+++ b/src/use_gestures.rs
@@ -2,9 +2,9 @@ use paste;
 use std::{cell::RefCell, rc::Rc};
 
 use dioxus::{
-    html::{PlatformEventData},
+    core::{AttributeValue, Event, ListenerCallback},
+    html::PlatformEventData,
     prelude::{use_hook, Attribute},
-    core::{ListenerCallback},
 };
 
 use crate::state::{
@@ -37,20 +37,20 @@ impl From<Gestures> for UseGestures {
     }
 }
 
-
 impl UseGestures {
     pub fn event_handlers(self) -> Vec<Attribute> {
-
         macro_rules! pointer_event_handler {
             ($attribute_name: ident, $function_name: ident) => {{
                 let pointer_ref = Rc::clone(&self.state);
-                dioxus_core::Attribute::new(
+                Attribute::new(
                     paste::paste! { stringify!([<$attribute_name:camel:lower>])},
-                    dioxus_core::AttributeValue::Listener(
-                        ListenerCallback::new(
-                        move |e: dioxus_core::Event<PlatformEventData>| {
-                            let _ = pointer_ref.try_borrow_mut().map(|mut s| s.$function_name(e.map(|data| data.into())));
-                        }).erase()
+                    AttributeValue::Listener(
+                        ListenerCallback::new(move |e: Event<PlatformEventData>| {
+                            let _ = pointer_ref
+                                .try_borrow_mut()
+                                .map(|mut s| s.$function_name(e.map(|data| data.into())));
+                        })
+                        .erase(),
                     ),
                     None,
                     false,


### PR DESCRIPTION
Removes the generational-box and dioxus-core dependencies that were previously needed on 0.6.x.

Closes #14, #15.